### PR TITLE
Reduce notifications

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -153,7 +153,7 @@ async function vsCodeUpdateSettingsFile() {
 	const os = getOsName();
 
 	if (!await isValid()) {
-		vscode.window.showErrorMessage(`No settings.${os}.json file found.`);
+		vscode.window.setStatusBarMessage(`OS Settings: No settings.${os}.json file found.`, 5000);
 		return;
 	}
 
@@ -165,7 +165,7 @@ async function vsCodeUpdateSettingsFile() {
 
 	try {
 		await updateSettingsFile();
-		vscode.window.showInformationMessage(`Updated settings.json for ${os} operating system.`);
+		vscode.window.setStatusBarMessage(`OS Settings: Updated settings.json for ${os}.`, 5000);
 	} catch (error) {
 		vscode.window.showErrorMessage(`Error updating settings.json: ${error.message}`);
 	}


### PR DESCRIPTION
Fixes #3.

For projects that don’t use OS-specific settings, there’s no need for an error message. And for projects that do, there’s no need for an info message.

I took the liberty of prefixing the message "OS Settings"... I wanted something short to identify the plugin. Change at will of course!